### PR TITLE
do not override annotations for bigdecimals and bigints

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -61,8 +61,8 @@ class SwaggerScalaModelConverter extends ModelResolver(Json.mapper()) {
 
   private def matchScalaPrimitives(`type`: AnnotatedType, nullableClass: Class[_]): Option[Schema[_]] = {
     val annotations = Option(`type`.getCtxAnnotations).map(_.toSeq).getOrElse(Seq.empty)
-    annotations.collectFirst { case ann: JsonScalaEnumeration => ann } match {
-      case Some(enumAnnotation) => {
+    annotations.headOption match {
+      case Some(enumAnnotation: JsonScalaEnumeration) => {
         val pt = enumAnnotation.value().getGenericSuperclass.asInstanceOf[ParameterizedType]
         val args = pt.getActualTypeArguments
         val cls = args(0).asInstanceOf[Class[Enumeration]]
@@ -75,6 +75,7 @@ class SwaggerScalaModelConverter extends ModelResolver(Json.mapper()) {
           sp
         }
       }
+      case Some(_) => None
       case _ => {
         Option(nullableClass).flatMap { cls =>
           if (cls == classOf[BigDecimal]) {

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -212,6 +212,39 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers {
     converter.readAll(classOf[Option[Int]])
   }
 
+  it should "process Model with Scala BigDecimal with annotation" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWBigDecimalAnnotated]).asScala.toMap
+    val model = findModel(schemas, "ModelWBigDecimalAnnotated")
+    model should be (defined)
+    model.get.getProperties should not be (null)
+    val field = model.get.getProperties.get("field")
+    field shouldBe a [StringSchema]
+    nullSafeList(model.get.getRequired) should not be empty
+  }
+
+  it should "process Model with Scala BigInt with annotation" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWBigIntAnnotated]).asScala.toMap
+    val model = findModel(schemas, "ModelWBigIntAnnotated")
+    model should be (defined)
+    model.get.getProperties should not be (null)
+    val field = model.get.getProperties.get("field")
+    field shouldBe a [StringSchema]
+    nullSafeList(model.get.getRequired) should not be empty
+  }
+
+  it should "process Model with Scala Enum with annotation" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWEnumAnnotated]).asScala.toMap
+    val model = findModel(schemas, "ModelWEnumAnnotated")
+    model should be (defined)
+    model.get.getProperties should not be (null)
+    val field = model.get.getProperties.get("field")
+    field shouldBe a [StringSchema]
+    nullSafeList(model.get.getRequired) should not be empty
+  }
+
   def findModel(schemas: Map[String, Schema[_]], name: String): Option[Schema[_]] = {
     schemas.get(name) match {
       case Some(m) => Some(m)

--- a/src/test/scala/models/ModelWBigDecimalAnnotated.scala
+++ b/src/test/scala/models/ModelWBigDecimalAnnotated.scala
@@ -1,0 +1,5 @@
+package models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+case class ModelWBigDecimalAnnotated(@Schema(description = "bigdecimal value", `type` = "string", example = "42.0", required = true) field: BigDecimal)

--- a/src/test/scala/models/ModelWBigIntAnnotated.scala
+++ b/src/test/scala/models/ModelWBigIntAnnotated.scala
@@ -1,0 +1,5 @@
+package models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+case class ModelWBigIntAnnotated(@Schema(description = "bigint value", `type` = "string", example = "42", required = true) field: BigInt)

--- a/src/test/scala/models/ModelWEnumAnnotated.scala
+++ b/src/test/scala/models/ModelWEnumAnnotated.scala
@@ -1,0 +1,5 @@
+package models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+case class ModelWEnumAnnotated(@Schema(description = "enum value", `type` = "string", required = true) field: OrderSize.Value)


### PR DESCRIPTION
In case if annotation for bigdecimal and bigint already set
this module will still override annotation to default `number` type