### PR TITLE
Nested option inside case class

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -89,6 +89,9 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             case Seq() => {
               val propertyClass = getPropertyClass(property)
               if (!isOption(propertyClass)) addRequiredItem(schema, property.name)
+              if (isOption(propertyClass) && schema.getRequired != null && schema.getRequired.contains(property.name)) {
+                schema.getRequired.remove(property.name)
+              }
             }
             case annotations => {
               val required = getRequiredSettings(annotations).headOption


### PR DESCRIPTION
When I generate schema for case class with nested option object `case class TestClass(testOption: Option[Set[String]])`, I get the following schema:
```
TestClass:
      required:
      - testOption
      type: object
      properties:
        testOption:
          uniqueItems: true
          type: array
          properties: {}
          items:
            type: string
```
`testOption` marked as required although it shouldn't.