### PR TITLE
Fix conversion of first-level Iterable[T]

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -57,16 +57,8 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
           case Some(property) => {
             if (isIterable(cls)) {
               //untidy solution for https://github.com/swagger-akka-http/swagger-scala-module/issues/48
-              val required = property.getRequired
-              if (required != null) {
-                required.remove("traversableAgain")
-                required.remove("empty")
-              }
-              val props = property.getProperties
-              if (props != null) {
-                props.remove("traversableAgain")
-                props.remove("empty")
-              }
+              property.setRequired(null)
+              property.setProperties(null)
             }
             setRequired(`type`)
             property

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -366,6 +366,15 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     nullSafeList(model.value.getRequired) shouldEqual Seq("listOfStrings")
   }
 
+  it should "process scala Iterable[T] classes" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[Seq[String]]).asScala.toMap
+    val model = findModel(schemas, "Seq")
+    model should be(defined)
+    model.value.getProperties should be(null)
+    model.value.getRequired should be(null)
+  }
+
   it should "process Array-Model with forced required Scala Option Seq" in {
     val converter = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionStringSeq]).asScala.toMap


### PR DESCRIPTION
Hi

I'm using the library within a spring boot project with the springdoc plugin. When I return a `Seq[T]` directly as a response (not nested into another class), then that first level Seq has the _properties_ and _required_ attributes assigned, which shouldn't be the case. It gives an error when rendering the Swagger UI and also the Swagger Editor at https://editor.swagger.io/ marks it with an error.

An example: The following Spring Boot Controller

```scala
@RestController
class TestController {

    @GetMapping(Array("/test"))
    def testEndpoint() = {
        Seq("A", "B")
    }

}
```

produces

```yaml
paths:
  /test:
    get:
      responses:
        '200':
          description: OK
          content:
            '*/*':
              schema:
                required: []
                type: array
                properties: {}
                items:
                  type: string
```

but I think it should be like that:

```yaml
paths:
  /test:
    get:
      responses:
        '200':
          description: OK
          content:
            '*/*':
              schema:
                type: array
                items:
                  type: string
```
I was digging into the problem and came across these lines:

https://github.com/swagger-akka-http/swagger-scala-module/blob/cc69c8e555739be07089a4fabf4256e998786388/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala#L58-L74

I think for iterable classes, _properties_ and _required_ should always be null, because the items in the array is defined in the _items_ field.

That's what I changed in that PR and I added a unittest for that. All other tests are still running fine.