### PR TITLE
Required Fields overwritten by default Schema value required=false

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -97,6 +97,8 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
               val required = getRequiredSettings(annotations).headOption
                 .getOrElse(!isOption(getPropertyClass(property)))
               if (required) addRequiredItem(schema, property.name)
+              val propertyClass = getPropertyClass(property)
+              if (!isOption(propertyClass)) addRequiredItem(schema, property.name)
             }
           }
         }

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -124,7 +124,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     optInt shouldBe a [IntegerSchema]
     nullSafeList(model.value.getRequired) shouldBe empty
   }
-  
+
   it should "process Model with Scala Option Boolean" in {
     val converter = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionBoolean]).asScala.toMap
@@ -372,6 +372,15 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     val model = findModel(schemas, "ModelWOptionStringSeq")
     model should be(defined)
     nullSafeList(model.value.getRequired) shouldBe empty
+  }
+
+  it should "process Model with required field annotated without required property" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWRequiredField]).asScala.toMap
+    val model = findModel(schemas, "ModelWRequiredField")
+    model should be(defined)
+    val reg = model.value.getRequired
+    nullSafeList(model.value.getRequired) shouldEqual Seq("requiredField")
   }
 
   private def findModel(schemas: Map[String, Schema[_]], name: String): Option[Schema[_]] = {

--- a/src/test/scala/models/ModelWRequiredField.scala
+++ b/src/test/scala/models/ModelWRequiredField.scala
@@ -1,0 +1,12 @@
+package models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * [[Schema]] annotation has default value for [[Schema#required()]] property=false
+ * It will overwrite by default required fields with required=false once annotation Schema will be applied without
+ * explicitly marking @Schema(required=true)
+ *
+ * @param requiredField
+ */
+case class ModelWRequiredField(@Schema(description = "required field without schema property required defined") requiredField: Int)


### PR DESCRIPTION
When mandatory field is annotated with Schema without explicitly configuring property `required` it will become not required implicitly.
That behavior correct for Java where fields can have `null` value, but not correct for Scala where we should use `Option[_]` 

Here is an example
```scala
case class ModelWRequiredField(
  @Schema(description = "required field without schema property required defined")
  requiredField: Int
)
```

which turns into
```yaml
type: object
properties:
  requiredField:
    type: integer
```

but I'm expecting 
```yaml
type: object
properties:
  requiredField:
    type: integer
required:
   - requiredField
```

Unfortunately offered PR conflicting with mandatory fields where i could force them  to be optional via annotation `required=false`. Please help to suggest to overcome that issue
