### PR TITLE
Save primitives from erasure (Scala2 only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
         run: sbt '++${{ matrix.scala }}' coverage test coverageReport
 
       - name: Scala build
-        if: '!startsWith(matrix.scala, ''2.13'')'
+        if: '!startsWith(matrix.scala, ''2.13'') && !startsWith(matrix.scala, ''3.0'')'
         run: sbt '++${{ matrix.scala }}' test
+
+      - name: Scala compile
+        if: startsWith(matrix.scala, '3.0')
+        run: sbt '++${{ matrix.scala }}' compile
 
       - name: Publish to Codecov.io
         if: startsWith(matrix.scala, '2.13')

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,6 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.36",
   "io.swagger.core.v3" % "swagger-core-jakarta" % "2.2.2",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.3",
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scalatest" %% "scalatest" % "3.2.11" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.36" % Test
 )
@@ -91,7 +90,8 @@ pomExtra := {
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("coverage", "test", "coverageReport"), name = Some("Scala 2.13 build"), cond = Some("startsWith(matrix.scala, '2.13')")),
-  WorkflowStep.Sbt(List("test"), name = Some("Scala build"), cond = Some("!startsWith(matrix.scala, '2.13')")),
+  WorkflowStep.Sbt(List("test"), name = Some("Scala build"), cond = Some("!startsWith(matrix.scala, '2.13') && !startsWith(matrix.scala, '3.0')")),
+  WorkflowStep.Sbt(List("compile"), name = Some("Scala compile"), cond = Some("startsWith(matrix.scala, '3.0')")),
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Zulu, "8"))

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.36",
   "io.swagger.core.v3" % "swagger-core-jakarta" % "2.2.2",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.3",
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scalatest" %% "scalatest" % "3.2.11" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.36" % Test
 )
@@ -63,10 +64,10 @@ licenses := Seq(("Apache License 2.0", new URL("http://www.apache.org/licenses/L
 
 pomExtra := {
   pomExtra.value ++ Group(
-      <issueManagement>
-        <system>github</system>
-        <url>https://github.com/swagger-api/swagger-scala-module/issues</url>
-      </issueManagement>
+    <issueManagement>
+      <system>github</system>
+      <url>https://github.com/swagger-api/swagger-scala-module/issues</url>
+    </issueManagement>
       <developers>
         <developer>
           <id>fehguy</id>

--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,12 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.11" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.36" % Test
 )
+libraryDependencies ++= {
+  CrossVersion.partialVersion(Keys.scalaVersion.value) match {
+    case Some((3, _)) => Seq()
+    case _ => Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  }
+}
 
 homepage := Some(new URL("https://github.com/swagger-akka-http/swagger-scala-module"))
 

--- a/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -1,32 +1,23 @@
 package com.github.swagger.scala.converter
 
-import io.swagger.v3.core.util.PrimitiveType
-import io.swagger.v3.oas.models.media.Schema
-
 object ErasureHelper {
 
-  def erasedOptionalPrimitives(cls: Class[_]): Map[String, Schema[_]] = {
+  def erasedOptionalPrimitives(cls: Class[_]): Map[String, Class[_]] = {
     import scala.reflect.runtime.universe
     val mirror = universe.runtimeMirror(cls.getClassLoader)
     val sym = mirror.staticClass(cls.getName)
     val properties = sym.selfType.members
       .filterNot(_.isMethod)
       .filterNot(_.isClass)
-      .map(prop => prop.name.toString.trim -> prop.typeSignature).toMap
 
-    properties.mapValues { typeSignature =>
-      if (typeSignature.typeSymbol.isClass && mirror.runtimeClass(typeSignature.typeSymbol.asClass) != classOf[scala.Option[_]]) {
-        None
-      } else {
-        val typeArg = typeSignature.typeArgs.headOption
-        typeArg.flatMap { signature =>
-          if (signature.typeSymbol.isClass) {
-            val runtimeClass = mirror.runtimeClass(signature.typeSymbol.asClass)
-            Option(PrimitiveType.fromType(runtimeClass)).map(_.createProperty())
-          } else None
-        }
+    properties.flatMap { prop =>
+      val maybeClass: Option[Class[_]] = prop.typeSignature.typeArgs.headOption.flatMap { signature =>
+        if (signature.typeSymbol.isClass) {
+          Option(mirror.runtimeClass(signature.typeSymbol.asClass))
+        } else None
       }
-    }.collect { case (k, Some(v)) => k -> v }.toMap
+      maybeClass.map(prop.name.toString.trim -> _)
+    }.toMap
   }
 
 }

--- a/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -1,0 +1,32 @@
+package com.github.swagger.scala.converter
+
+import io.swagger.v3.core.util.PrimitiveType
+import io.swagger.v3.oas.models.media.Schema
+
+object ErasureHelper {
+
+  def erasedOptionalPrimitives(cls: Class[_]): Map[String, Schema[_]] = {
+    import scala.reflect.runtime.universe
+    val mirror = universe.runtimeMirror(cls.getClassLoader)
+    val sym = mirror.staticClass(cls.getName)
+    val properties = sym.selfType.members
+      .filterNot(_.isMethod)
+      .filterNot(_.isClass)
+      .map(prop => prop.name.toString.trim -> prop.typeSignature).toMap
+
+    properties.mapValues { typeSignature =>
+      if (typeSignature.typeSymbol.isClass && mirror.runtimeClass(typeSignature.typeSymbol.asClass) != classOf[scala.Option[_]]) {
+        None
+      } else {
+        val typeArg = typeSignature.typeArgs.headOption
+        typeArg.flatMap { signature =>
+          if (signature.typeSymbol.isClass) {
+            val runtimeClass = mirror.runtimeClass(signature.typeSymbol.asClass)
+            Option(PrimitiveType.fromType(runtimeClass)).map(_.createProperty())
+          } else None
+        }
+      }
+    }.collect { case (k, Some(v)) => k -> v }.toMap
+  }
+
+}

--- a/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -1,0 +1,11 @@
+package com.github.swagger.scala.converter
+
+import io.swagger.v3.oas.models.media.Schema
+
+
+object ErasureHelper {
+
+  def erasedOptionalPrimitives(cls: Class[_]): Map[String, Class[_]] =  Map.empty[String, Class[_]]
+
+}
+

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -32,6 +32,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
   private val EnumClass = classOf[scala.Enumeration]
   private val OptionClass = classOf[scala.Option[_]]
   private val IterableClass = classOf[scala.collection.Iterable[_]]
+  private val MapClass = classOf[Map[_, _]]
   private val SetClass = classOf[scala.collection.Set[_]]
   private val BigDecimalClass = classOf[BigDecimal]
   private val BigIntClass = classOf[BigInt]
@@ -79,24 +80,30 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
       Option(chain.next().resolve(`type`, context, chain)).map { schema =>
         val introspector = BeanIntrospector(cls)
         introspector.properties.foreach { property =>
+
           val propertyClass = getPropertyClass(property)
+          val isOptional = isOption(propertyClass)
+
           erasedProperties.get(property.name).foreach { erasedType =>
-            if (isOption(propertyClass)) {
-              overrideImplementationOfAnnotationSchema(schema, erasedType, property.name)
+            val primitiveType = PrimitiveType.fromType(erasedType)
+            if (primitiveType != null && isOptional) {
+              updateTypeOnSchema(schema, primitiveType, property.name)
+            }
+            if (primitiveType != null && isIterable(propertyClass) && !isMap(propertyClass)) {
+              updateTypeOnItemsSchema(schema, primitiveType, property.name)
             }
           }
           getPropertyAnnotations(property) match {
             case Seq() => {
-              val optionalFlag = isOption(propertyClass)
-              if (optionalFlag && schema.getRequired != null && schema.getRequired.contains(property.name)) {
+              if (isOptional && schema.getRequired != null && schema.getRequired.contains(property.name)) {
                 schema.getRequired.remove(property.name)
-              } else if (!optionalFlag) {
+              } else if (!isOptional) {
                 addRequiredItem(schema, property.name)
               }
             }
             case annotations => {
               val required = getRequiredSettings(annotations).headOption
-                .getOrElse(!isOption(propertyClass))
+                .getOrElse(!isOptional)
               if (required) addRequiredItem(schema, property.name)
             }
           }
@@ -108,16 +115,26 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
     }
   }
 
-  private def overrideImplementationOfAnnotationSchema(schema: Schema[_], erasedType: Class[_], propertyName: String) = {
-    val primitiveType = PrimitiveType.fromType(erasedType)
-    if (primitiveType == null) {
-      schema
-    } else {
-      val prop = schema.getProperties.get(propertyName)
-      val propAsString = objectMapper.writeValueAsString(prop)
-      val parsedSchema = objectMapper.readValue(propAsString, primitiveType.createProperty().getClass)
-      schema.addProperty(propertyName, parsedSchema)
-    }
+  private def updateTypeOnSchema(schema: Schema[_], primitiveType: PrimitiveType, propertyName: String) = {
+    val property = schema.getProperties.get(propertyName)
+    val updatedSchema = correctSchema(property, primitiveType)
+    schema.addProperty(propertyName, updatedSchema)
+  }
+
+  private def updateTypeOnItemsSchema(schema: Schema[_], primitiveType: PrimitiveType, propertyName: String) = {
+    val property = schema.getProperties.get(propertyName)
+    val updatedSchema = correctSchema(property.getItems, primitiveType)
+    property.setItems(updatedSchema)
+    schema.addProperty(propertyName, property)
+  }
+
+  private def correctSchema(itemSchema: Schema[_], primitiveType: PrimitiveType) = {
+    val primitiveProperty = primitiveType.createProperty()
+    val propAsString = objectMapper.writeValueAsString(itemSchema)
+    val correctedSchema = objectMapper.readValue(propAsString, primitiveProperty.getClass)
+    correctedSchema.setType(primitiveProperty.getType)
+    correctedSchema.setFormat(primitiveProperty.getFormat)
+    correctedSchema
   }
 
   private def getRequiredSettings(annotatedType: AnnotatedType): Seq[Boolean] = annotatedType match {
@@ -296,6 +313,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
 
   private def isOption(cls: Class[_]): Boolean = cls == OptionClass
   private def isIterable(cls: Class[_]): Boolean = IterableClass.isAssignableFrom(cls)
+  private def isMap(cls: Class[_]): Boolean = MapClass.isAssignableFrom(cls)
   private def isCaseClass(cls: Class[_]): Boolean = ProductClass.isAssignableFrom(cls)
 
   private def nullSafeList[T](array: Array[T]): List[T] = Option(array) match {

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -338,6 +338,23 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     nullSafeList(arraySchema.getRequired()) shouldBe empty
   }
 
+  it should "process Model with Scala Seq Int" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWSeqInt]).asScala.toMap
+    val model = findModel(schemas, "ModelWSeqInt")
+    model should be(defined)
+    model.value.getProperties should not be (null)
+
+    val stringsField = model.value.getProperties.get("ints")
+
+    stringsField shouldBe a[ArraySchema]
+    val arraySchema = stringsField.asInstanceOf[ArraySchema]
+    arraySchema.getUniqueItems() shouldBe (null)
+    arraySchema.getItems shouldBe a[ObjectSchema]
+    nullSafeMap(arraySchema.getProperties()) shouldBe empty
+    nullSafeList(arraySchema.getRequired()) shouldBe empty
+  }
+
   it should "process Model with Scala Set" in {
     val converter = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWSetString]).asScala.toMap

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -107,9 +107,10 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     val model = schemas.get("ModelWOptionInt")
     model should be (defined)
     model.value.getProperties should not be (null)
-    val optInt = model.value.getProperties().get("optInt")
+    val optInt = model.value.getProperties.get("optInt")
     optInt should not be (null)
-    optInt shouldBe a [Schema[_]]
+    optInt shouldBe a [IntegerSchema]
+    optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
     nullSafeList(model.value.getRequired) shouldBe empty
   }
 
@@ -134,7 +135,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     model.value.getProperties should not be (null)
     val optLong = model.value.getProperties().get("optLong")
     optLong should not be (null)
-    optLong shouldBe a [Schema[_]]
+    optLong shouldBe a [IntegerSchema]
     nullSafeList(model.value.getRequired) shouldBe empty
   }
 

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -350,7 +350,27 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     stringsField shouldBe a[ArraySchema]
     val arraySchema = stringsField.asInstanceOf[ArraySchema]
     arraySchema.getUniqueItems() shouldBe (null)
-    arraySchema.getItems shouldBe a[ObjectSchema]
+    arraySchema.getItems shouldBe a[IntegerSchema]
+    nullSafeMap(arraySchema.getProperties()) shouldBe empty
+    nullSafeList(arraySchema.getRequired()) shouldBe empty
+  }
+
+  it should "process Model with Scala Seq Int (annotated)" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWSeqIntAnnotated]).asScala.toMap
+    val model = findModel(schemas, "ModelWSeqIntAnnotated")
+    model should be(defined)
+    model.value.getProperties should not be (null)
+
+    val stringsField = model.value.getProperties.get("ints")
+
+    stringsField shouldBe a[ArraySchema]
+    val arraySchema = stringsField.asInstanceOf[ArraySchema]
+    arraySchema.getUniqueItems() shouldBe (null)
+
+
+    arraySchema.getItems shouldBe a[IntegerSchema]
+    arraySchema.getItems.getDescription shouldBe "These are ints"
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
     nullSafeList(arraySchema.getRequired()) shouldBe empty
   }

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -124,7 +124,20 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     optInt should not be (null)
     optInt shouldBe a [IntegerSchema]
     optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
+    optInt.getDescription shouldBe "This is an optional int"
     nullSafeList(model.value.getRequired) shouldBe empty
+  }
+
+  it should "allow annotation to override required with Scala Option Int" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWOptionIntSchemaOverrideForRequired]).asScala.toMap
+    val model = schemas.get("ModelWOptionIntSchemaOverrideForRequired")
+    model should be(defined)
+    model.value.getProperties should not be (null)
+    val optInt = model.value.getProperties().get("optInt")
+    optInt should not be (null)
+    optInt shouldBe an [IntegerSchema]
+    nullSafeList(model.value.getRequired) shouldEqual Seq("optInt")
   }
 
   it should "process Model with Scala Option Long" in {

--- a/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
@@ -85,7 +85,7 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
     val model = schemas("ModelWithIntVector")
     val prop = model.getProperties().get("ints")
     prop shouldBe a [ArraySchema]
-    prop.asInstanceOf[ArraySchema].getItems.getType should be ("object")
+    prop.asInstanceOf[ArraySchema].getItems.getType should be ("integer")
   }
 
   it should "read a model with vector of booleans" in {
@@ -93,7 +93,7 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
     val model = schemas("ModelWithBooleanVector")
     val prop = model.getProperties().get("bools")
     prop shouldBe a [ArraySchema]
-    prop.asInstanceOf[ArraySchema].getItems.getType should be ("object")
+    prop.asInstanceOf[ArraySchema].getItems.getType should be ("boolean")
   }
 }
 

--- a/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
@@ -70,7 +70,7 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
 
     val date = userSchema.getProperties().get("date")
     date shouldBe a [DateTimeSchema]
-    //date.getDescription should be ("the birthdate")
+//    date.getDescription should be ("the birthdate")
   }
 
   it should "read a model with vector property" in {

--- a/src/test/scala/models/ModelWOptionInt.scala
+++ b/src/test/scala/models/ModelWOptionInt.scala
@@ -4,4 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 case class ModelWOptionInt(optInt: Option[Int])
 
-case class ModelWOptionIntSchemaOverride(@Schema(implementation = classOf[Int]) optInt: Option[Int])
+case class ModelWOptionIntSchemaOverride(@Schema(description = "This is an optional int") optInt: Option[Int])
+
+case class ModelWOptionIntSchemaOverrideForRequired(@Schema(required = true) optInt: Option[Int])

--- a/src/test/scala/models/ModelWSeqInt.scala
+++ b/src/test/scala/models/ModelWSeqInt.scala
@@ -1,0 +1,3 @@
+package models
+
+case class ModelWSeqInt(ints: Seq[Int])

--- a/src/test/scala/models/ModelWSeqInt.scala
+++ b/src/test/scala/models/ModelWSeqInt.scala
@@ -1,3 +1,7 @@
 package models
 
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Schema}
+
 case class ModelWSeqInt(ints: Seq[Int])
+
+case class ModelWSeqIntAnnotated(@ArraySchema(arraySchema = new Schema(required = false), schema = new Schema(description = "These are ints")) ints: Seq[Int])


### PR DESCRIPTION
This PR attempts to address the issue that optional and iterable Java primitive types e.g. `Option[Int]`, `Seq[Boolean]` are lost in translation as described in https://github.com/swagger-akka-http/swagger-scala-module/issues/117.

Note that this implementation depends on scala reflection and therefore does not work in Scala 3. There is a stub method `ErasureHelper.erasedOptionalPrimitives(cls: Class[_]): Map[String, Class[_]]` that would need to be implemented using macros(?).
I may have a stab at that later, but I'm completely new to Scala 3 or macros for that matter. So if someone else know how to do this, help with that would be much appreciated!