### PR TITLE
issue where schema annotations can be ignored (after recent changes)

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -29,6 +29,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
   SwaggerScalaModelConverter
 
   private val logger = LoggerFactory.getLogger(classOf[SwaggerScalaModelConverter])
+  private val VoidClass = classOf[Void]
   private val EnumClass = classOf[scala.Enumeration]
   private val OptionClass = classOf[scala.Option[_]]
   private val IterableClass = classOf[scala.collection.Iterable[_]]
@@ -83,7 +84,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
           val isOptional = isOption(propertyClass)
           val propertyAnnotations = getPropertyAnnotations(property)
           val schemaOverrideClass = propertyAnnotations.collectFirst {
-            case s: SchemaAnnotation => s.implementation()
+            case s: SchemaAnnotation if s.implementation() != VoidClass => s.implementation()
           }
           if (schemaOverrideClass.isEmpty) {
             erasedProperties.get(property.name).foreach { erasedType =>

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -79,20 +79,24 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
         val introspector = BeanIntrospector(cls)
         val erasedProperties = ErasureHelper.erasedOptionalPrimitives(cls)
         introspector.properties.foreach { property =>
-
           val propertyClass = getPropertyClass(property)
           val isOptional = isOption(propertyClass)
-
-          erasedProperties.get(property.name).foreach { erasedType =>
-            val primitiveType = PrimitiveType.fromType(erasedType)
-            if (primitiveType != null && isOptional) {
-              updateTypeOnSchema(schema, primitiveType, property.name)
-            }
-            if (primitiveType != null && isIterable(propertyClass) && !isMap(propertyClass)) {
-              updateTypeOnItemsSchema(schema, primitiveType, property.name)
+          val propertyAnnotations = getPropertyAnnotations(property)
+          val schemaOverrideClass = propertyAnnotations.collectFirst {
+            case s: SchemaAnnotation => s.implementation()
+          }
+          if (schemaOverrideClass.isEmpty) {
+            erasedProperties.get(property.name).foreach { erasedType =>
+              val primitiveType = PrimitiveType.fromType(erasedType)
+              if (primitiveType != null && isOptional) {
+                updateTypeOnSchema(schema, primitiveType, property.name)
+              }
+              if (primitiveType != null && isIterable(propertyClass) && !isMap(propertyClass)) {
+                updateTypeOnItemsSchema(schema, primitiveType, property.name)
+              }
             }
           }
-          getPropertyAnnotations(property) match {
+          propertyAnnotations match {
             case Seq() => {
               if (isOptional && schema.getRequired != null && schema.getRequired.contains(property.name)) {
                 schema.getRequired.remove(property.name)

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -182,6 +182,19 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     nullSafeList(model.value.getRequired) shouldBe empty
   }
 
+  it should "process Model with Scala Option Long with Schema Int Override" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWOptionLongSchemaIntOverride]).asScala.toMap
+    val model = schemas.get("ModelWOptionLongSchemaIntOverride")
+    model should be(defined)
+    model.value.getProperties should not be (null)
+    val optLong = model.value.getProperties().get("optLong")
+    optLong should not be (null)
+    optLong shouldBe a[IntegerSchema]
+    optLong.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
+    nullSafeList(model.value.getRequired) shouldBe empty
+  }
+
   it should "process Model with Scala Option Boolean" in {
     val converter = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionBoolean]).asScala.toMap

--- a/src/test/scala/models/ModelWOptionLong.scala
+++ b/src/test/scala/models/ModelWOptionLong.scala
@@ -5,3 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 case class ModelWOptionLong(optLong: Option[Long])
 
 case class ModelWOptionLongSchemaOverride(@Schema(implementation = classOf[Long]) optLong: Option[Long])
+
+case class ModelWOptionLongSchemaIntOverride(@Schema(implementation = classOf[Int]) optLong: Option[Long])


### PR DESCRIPTION
The underlying issue is that https://github.com/swagger-akka-http/swagger-scala-module/pull/166 kicks in even if a user has specified a swagger annotation that sets their own schema.