### PR TITLE
Add global setting to ignore `required` option on @Schema

### DIFF
--- a/src/test/scala/models/ModelWOptionInt.scala
+++ b/src/test/scala/models/ModelWOptionInt.scala
@@ -22,4 +22,9 @@ object NestingObject {
 
 case class ModelWOptionIntSchemaOverride(@Schema(description = "This is an optional int") optInt: Option[Int])
 
-case class ModelWOptionIntSchemaOverrideForRequired(@Schema(required = true) optInt: Option[Int])
+
+case class ModelWOptionIntSchemaOverrideForRequired(requiredInt: Int,
+                  optionalInt: Option[Int],
+                  @Schema(description = "should stay required") annotatedRequiredInt: Int,
+                  @Schema(description = "should become required", required = true) annotatedOptionalInt: Option[Int]
+                 )


### PR DESCRIPTION
so that users can opt to trust the type system rather than the annotations to decide whether a field is required or not.

This addresses the problem as described by @chameleon82 in https://github.com/swagger-akka-http/swagger-scala-module/pull/128.

The default behavior is unchanged.