### PR TITLE
Consider fields with default value optional

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -127,19 +127,20 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
               }
             }
           }
+          val noDefault = property.param.flatMap(_.defaultValue).isEmpty
           propertyAnnotations match {
             case Seq() => {
               if (isOptional && schema.getRequired != null && schema.getRequired.contains(property.name)) {
-                schema.getRequired.remove(property.name)
-              } else if (!isOptional) {
-                addRequiredItem(schema, property.name)
+                schema.getRequired.remove(propertyName)
+              } else if (!isOptional && (SwaggerScalaModelConverter.requiredBasedOnAnnotation || noDefault)) {
+                addRequiredItem(schema, propertyName)
               }
             }
             case annotations => {
               val annotationSetting = getRequiredSettings(annotations).headOption.getOrElse(false)
               val required = if (isOptional || SwaggerScalaModelConverter.requiredBasedOnAnnotation) {
                 annotationSetting
-              } else { true }
+              } else { noDefault }
 
               if (required) addRequiredItem(schema, property.name)
             }

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -200,6 +200,11 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val converter: ModelConverters = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionIntSchemaOverrideForRequired]).asScala.toMap
     val model = schemas.get("ModelWOptionIntSchemaOverrideForRequired")
+
+    val requiredIntWithDefault = model.value.getProperties.get("requiredIntWithDefault")
+    requiredIntWithDefault shouldBe an[IntegerSchema]
+    requiredIntWithDefault.asInstanceOf[IntegerSchema].getDefault shouldEqual 5
+
     nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "requiredInt", "requiredIntWithDefault")
   }
 
@@ -209,6 +214,11 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val converter: ModelConverters = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionIntSchemaOverrideForRequired]).asScala.toMap
     val model = schemas.get("ModelWOptionIntSchemaOverrideForRequired")
+
+    val requiredIntWithDefault = model.value.getProperties.get("requiredIntWithDefault")
+    requiredIntWithDefault shouldBe an[IntegerSchema]
+    requiredIntWithDefault.asInstanceOf[IntegerSchema].getDefault shouldEqual 5
+
     nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "requiredInt", "annotatedRequiredInt")
   }
 

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -200,7 +200,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val converter: ModelConverters = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionIntSchemaOverrideForRequired]).asScala.toMap
     val model = schemas.get("ModelWOptionIntSchemaOverrideForRequired")
-    nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "requiredInt")
+    nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "requiredInt", "requiredIntWithDefault")
   }
 
 
@@ -209,7 +209,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val converter: ModelConverters = ModelConverters.getInstance()
     val schemas = converter.readAll(classOf[ModelWOptionIntSchemaOverrideForRequired]).asScala.toMap
     val model = schemas.get("ModelWOptionIntSchemaOverrideForRequired")
-    nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "annotatedRequiredInt", "requiredInt")
+    nullSafeSeq(model.value.getRequired).toSet shouldEqual Set("annotatedOptionalInt", "requiredInt", "annotatedRequiredInt")
   }
 
   it should "process Model with Scala Option Long" in {

--- a/src/test/scala/models/ModelWOptionInt.scala
+++ b/src/test/scala/models/ModelWOptionInt.scala
@@ -24,7 +24,9 @@ case class ModelWOptionIntSchemaOverride(@Schema(description = "This is an optio
 
 
 case class ModelWOptionIntSchemaOverrideForRequired(requiredInt: Int,
-                  optionalInt: Option[Int],
-                  @Schema(description = "should stay required") annotatedRequiredInt: Int,
-                  @Schema(description = "should become required", required = true) annotatedOptionalInt: Option[Int]
-                 )
+                                                    requiredIntWithDefault: Int = 5,
+                                                    optionalInt: Option[Int],
+                                                    @Schema(description = "should stay required") annotatedRequiredInt: Int,
+                                                    @Schema(description = "should become optional") annotatedRequiredIntWithDefault: Int = 5,
+                                                    @Schema(description = "should become required", required = true) annotatedOptionalInt: Option[Int]
+                                                   )


### PR DESCRIPTION
If a field has a default value (and `isRequiredBasedOnAnnotation == false`), we can consider it as not required. After all, the consumer of the API does not need to specify a value in that case.

If a default value is found, it is added to the schema:
```json
"requiredIntWithDefault" : {
  "type" : "integer",
  "format" : "int32",
  "default" : 5
}
```