### PR TITLE
Fix Extraneous Array Schemas

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -107,6 +107,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
         nextResolved match {
           case Some(property) => {
             if (isIterable(cls)) {
+              property.setName(null)
               property.setRequired(null)
               property.setProperties(null)
             }

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -107,9 +107,9 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
         nextResolved match {
           case Some(property) => {
             if (isIterable(cls)) {
-              property.setName(null)
               property.setRequired(null)
               property.setProperties(null)
+              if (`type`.getParent != null) property.setName(null)
             }
             setRequired(`type`)
             property

--- a/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ScalaModelTest.scala
@@ -75,6 +75,8 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
 
   it should "read a model with vector property" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithVector]).asScala
+    schemas.size shouldBe 1
+
     val model = schemas("ModelWithVector")
     val friends = model.getProperties().get("friends")
     friends shouldBe a[ArraySchema]
@@ -82,6 +84,8 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
 
   it should "read a model with vector of ints" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithIntVector]).asScala
+    schemas.size shouldBe 1
+
     val model = schemas("ModelWithIntVector")
     val prop = model.getProperties().get("ints")
     prop shouldBe a[ArraySchema]
@@ -90,6 +94,8 @@ class ScalaModelTest extends AnyFlatSpec with Matchers {
 
   it should "read a model with vector of booleans" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithBooleanVector]).asScala
+    schemas.size shouldBe 1
+
     val model = schemas("ModelWithBooleanVector")
     val prop = model.getProperties().get("bools")
     prop shouldBe a[ArraySchema]


### PR DESCRIPTION
fixes https://github.com/swagger-akka-http/swagger-scala-module/issues/195

I think I figured out the issue in the referenced ticket, at least, this fix works for me in a spec with over 500 schemas and paths... 

Apologies in advance for a terrible explanation:

From my understanding in the final case where the resolver eventually calls the next converter on the chain, which I believe to be the default converter in `swagger-core`, we are provided with a schema not processed by this library. In the specific case that this schema is for an iterable type property, the converter comes up with some nonsense name for the schema, i.e. `SeqString` which results in it being treated as a root level schema. By removing the name, this schema somehow gets removed from the output.