### PR TITLE
Add reproduction test for UnsupportedOperationException

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -223,7 +223,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
       propNamesSet.contains(key)
     }
     if (originalProps.size > newProps.size) {
-      schema.setProperties(newProps.asJava)
+      schema.setProperties(new util.LinkedHashMap(newProps.asJava))
     }
   }
 

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -540,6 +540,16 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     nullSafeSeq(model.value.getRequired) shouldEqual Seq("amount")
   }
 
+  it should "process ModelWGetFunction with optional field" in new PropertiesScope[ModelWGetFunctionWithOptionalField] {
+    val props = nullSafeMap(model.value.getProperties)
+    props should have size 1
+    val amountField = props.get("amount").value
+    amountField shouldBe a[IntegerSchema]
+    amountField.asInstanceOf[IntegerSchema].getFormat shouldEqual "int64"
+
+    nullSafeSeq(model.value.getRequired) shouldBe empty
+  }
+
   it should "process ModelWJacksonAnnotatedGetFunction" in new PropertiesScope[ModelWJacksonAnnotatedGetFunction] {
     val props = nullSafeMap(model.value.getProperties)
     props should have size 1

--- a/src/test/scala/models/ModelWGetFunction.scala
+++ b/src/test/scala/models/ModelWGetFunction.scala
@@ -6,6 +6,10 @@ case class ModelWGetFunction(amount: Long) {
   def getOptionalAmount(): Option[Long] = Some(amount)
 }
 
+case class ModelWGetFunctionWithOptionalField(amount: Option[Long]) {
+  def getOptionalAmount(): Option[Long] = amount
+}
+
 case class ModelWJacksonAnnotatedGetFunction(amount: Long) {
   @JsonIgnore def getOptionalAmount(): Option[Long] = Some(amount)
 }


### PR DESCRIPTION
caused by `java.base/java.util.AbstractMap.put` on a scala wrapped hash
map. The properties are initialized with it at the point where unwanted properties
are filtered out.
