### PR TITLE
List is seen as scala class in scala 2.12

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -129,7 +129,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
         resolve(nextType(baseType, `type`, javaType), context, chain)
       } else if (!annotatedOverrides.headOption.getOrElse(true)) {
         resolve(nextType(new AnnotatedTypeForOption(), `type`, javaType), context, chain)
-      } else if (isScalaClass(cls)) {
+      } else if (isScalaClass(cls) && !isIterable(cls)) {
         scalaClassSchema(cls, `type`, context, chain).getOrElse(None.orNull)
       } else if (chain.hasNext) {
         val nextResolved = Option(chain.next().resolve(`type`, context, chain))

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -461,7 +461,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     stringsField shouldBe an[ArraySchema]
     val arraySchema = stringsField.asInstanceOf[ArraySchema]
     arraySchema.getUniqueItems shouldBe null
-    arraySchema.getRequired shouldBe empty
+    arraySchema.getRequired shouldBe null
     arraySchema.getItems shouldBe a[ObjectSchema] // probably type erasure - ideally this would eval as StringSchema
     // next line used to fail (https://github.com/swagger-akka-http/swagger-akka-http/issues/171)
     Json.mapper().writeValueAsString(model.value)

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -458,9 +458,10 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     model should be(defined)
     model.value.getProperties should not be (null)
     val stringsField = model.value.getProperties.get("items")
-    stringsField shouldBe a[ArraySchema]
+    stringsField shouldBe an[ArraySchema]
     val arraySchema = stringsField.asInstanceOf[ArraySchema]
-    arraySchema.getUniqueItems() shouldBe (null)
+    arraySchema.getUniqueItems shouldBe null
+    arraySchema.getRequired shouldBe empty
     arraySchema.getItems shouldBe a[ObjectSchema] // probably type erasure - ideally this would eval as StringSchema
     // next line used to fail (https://github.com/swagger-akka-http/swagger-akka-http/issues/171)
     Json.mapper().writeValueAsString(model.value)


### PR DESCRIPTION
Before:
```json
    "properties": {
        "items": {
            "required": [
                "empty"
            ],
            "type": "array",
            "properties": {},
            "items": {
                "type": "object"
            },
        },
        "limit": {
            "type": "integer",
            "format": "int32"
        }
```
after:
```json
    "properties": {
        "items": {
            "items": {
                "type": "object"
            },
            "type": "array"
        },
        "limit": {
            "format": "int32",
            "type": "integer"
        },
 ```