### PR TITLE
Make correction of erased types a best effort

### DIFF
--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -1,7 +1,7 @@
 package com.github.swagger.scala.converter
 
 import io.swagger.v3.core.converter._
-import io.swagger.v3.core.util.Json
+import io.swagger.v3.core.util.{Json, PrimitiveType}
 import io.swagger.v3.oas.models.media._
 import models.NestingObject.{NestedModelWOptionInt, NoProperties}
 import models._
@@ -465,6 +465,20 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getItems shouldBe a[ObjectSchema] // probably type erasure - ideally this would eval as StringSchema
     // next line used to fail (https://github.com/swagger-akka-http/swagger-akka-http/issues/171)
     Json.mapper().writeValueAsString(model.value)
+  }
+
+  it should "default to supplied schema if it can't be corrected" in new PropertiesScope[ModelWMapStringCaseClass] {
+    schemas should have size 2
+
+    val mapField = model.value.getProperties.get("maybeMapStringCaseClass")
+    mapField shouldBe a[MapSchema]
+    mapField.getAdditionalProperties shouldBe a[Schema[_]]
+    mapField.getAdditionalProperties.asInstanceOf[Schema[_]].get$ref() shouldBe "#/components/schemas/SomeCaseClass"
+
+
+    val caseClassField = schemas("SomeCaseClass")
+    caseClassField shouldBe a[Schema[_]]
+    caseClassField.getProperties.get("field") shouldBe an[IntegerSchema]
   }
 
   it should "process Model with Scala Seq" in new PropertiesScope[ModelWSeqString] {

--- a/src/test/scala/models/ModelWSeqString.scala
+++ b/src/test/scala/models/ModelWSeqString.scala
@@ -8,4 +8,8 @@ case class ModelWJavaListString(strings: java.util.List[String])
 
 case class ModelWMapString(strings: Map[String, String])
 
+case class SomeCaseClass(field: Int)
+
+case class ModelWMapStringCaseClass(maybeMapStringCaseClass: Option[Map[String, SomeCaseClass]])
+
 case class ModelWJavaMapString(strings: java.util.Map[String, String])


### PR DESCRIPTION
Fixes https://github.com/swagger-akka-http/swagger-scala-module/issues/208

Fall back to original schema if correction fails for whatever reason.

Motivation: correcting a previously erased type should be a best effort and should not hard fail the generation of the entire model. Users may no always have control over the case classes they feed the model converter.

Example from our codebase, when including an [elastic search](https://www.elastic.co/) class in our API:
```
  com.fasterxml.jackson.databind.JsonMappingException: additionalProperties must be either a Boolean or a Schema instance
[info]  at [Source: (String)"{"type":"object","additionalProperties":{"type":"object"}}"; line: 1, column: 57] (through reference chain: io.swagger.v3.oas.models.media.StringSchema["additionalProperties"])
[info]   at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:276)
[info]   at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:627)
[info]   at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:615)
[info]   at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:143)
```