### PR TITLE
Do not add required value if we are dealing with an enum

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -223,7 +223,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
               val requiredFlag = !isOptional && (!SwaggerScalaModelConverter.isRequiredBasedOnDefaultValue || !hasDefaultValue)
               if (!requiredFlag && Option(schema.getRequired).isDefined && schema.getRequired.contains(propertyName)) {
                 schema.getRequired.remove(propertyName)
-              } else if (requiredFlag) {
+              } else if (requiredFlag && schema.getEnum == null) {
                 addRequiredItem(schema, propertyName)
               }
             }


### PR DESCRIPTION
The values in the trait are added as required since https://github.com/swagger-akka-http/swagger-scala-module/pull/191.
However, Enumeratum enums are sealed traits. We don't want to display the values (as required) in that case.
