### PR TITLE
Avoid empty list of required properties in rendered schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a fork of https://github.com/swagger-api/swagger-scala-module.
 | ------- | -------- |
 | 2.9.x | Refactor to support Swagger Schema annotation requiredMode. Jackson 2.14. |
 | 2.8.x | Builds on the 2.7.x changes. Jackson 2.14. |
-| 2.7.x | Scala 2 builds reintroduce scala-reflect dependency and can now introspect better on inner types. See section on `Treatment of Option` below. This has turned into a series with many experimental changes. It is probably best to upgrade to 2.8.x releases. |
+| 2.7.x | Scala 2 builds reintroduce scala-reflect dependency and can now introspect better on inner types. See section on `Treatment of Option` below. This has turned into a series with many experimental changes. It is probably best to upgrade to 2.8.x or later releases. |
 | 2.6.x/2.5.x | First releases to support Scala 3. Jackson 2.13, [jakarta](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started) namespace jars. [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification) / [Swagger-Core](https://github.com/swagger-api/swagger-core) 2.0.x. |
 | 2.4.x | First releases to support [jakarta](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started) namespace jars. Jackson 2.12, [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification) / [Swagger-Core](https://github.com/swagger-api/swagger-core) 2.0.x. |
 | 2.3.x | [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification) / [Swagger-Core](https://github.com/swagger-api/swagger-core) 2.0.x. |
@@ -31,7 +31,7 @@ When users add swagger annotations (Schema, ArraySchema, Parameter), they can ov
 
 The annotations mentioned above have a `required()` setting which is boolean and defaults to false. It is impossible to know if the user explicitly set false or if the are using the annotations to override other settings but don't intend to affect the required setting.
 
-swagger v2.2.5 introduces a `requiredMode()` setting on the Schema and ArraySchema annotations. The modes are Required, Not_Required and Auto - the latter is the default. This is better - but the `required()` setting, while deprecated, is still there and is set independently of the `requiredMode()`.
+Swagger v2.2.5 introduces a `requiredMode()` setting on the Schema and ArraySchema annotations. The modes are Required, Not_Required and Auto - the latter is the default. This is better - but the `required()` setting, while deprecated, is still there and is set independently of the `requiredMode()`.
 
 The treatment of `required()=false` prior to v2.9 is described in the below. [SwaggerScalaModelConverter.setRequiredBasedOnAnnotation](https://github.com/swagger-akka-http/swagger-scala-module/blob/bf97024492d07d7a293f72e4f113e9f378465bc2/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala#L44) and [SwaggerScalaModelConverter.setRequiredBasedOnDefaultValue](https://github.com/swagger-akka-http/swagger-scala-module/blob/bf97024492d07d7a293f72e4f113e9f378465bc2/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala#L58) will continue to affect how `required()=false` is interpreted.
 
@@ -53,7 +53,7 @@ With Collections (and Options), scala primitives are affected by type erasure. Y
 case class AddOptionRequest(number: Int, @Schema(required = false, implementation = classOf[Int]) number2: Option[Int] = None)
 ```
 
-Alternatively, you can non-primitive types like BigInt to avoid this requirement.
+Alternatively, you can use non-primitive types like BigInt to avoid this requirement.
 
 Since the v2.7 releases, Scala 2 builds use scala-reflect jar to try to work out the class information for the inner types. Since v2.7.5, Scala 3 builds use a lib that supports runtime reflection. See https://github.com/swagger-akka-http/swagger-scala-module/issues/117. One issue affacting Scala 3 users is https://github.com/gzoller/scala-reflection/issues/40.
 

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory
 import java.lang.annotation.Annotation
 import java.lang.reflect.ParameterizedType
 import java.util
+import java.util.List
 import scala.collection.JavaConverters._
-import scala.collection.Seq
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -279,7 +279,9 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             case Seq() => {
               val requiredFlag = !isOptional && (!SwaggerScalaModelConverter.isRequiredBasedOnDefaultValue || !hasDefaultValue)
               if (!requiredFlag && Option(schema.getRequired).isDefined && schema.getRequired.contains(propertyName)) {
-                schema.getRequired.remove(propertyName)
+                val requiredFields = new util.ArrayList[String](schema.getRequired)
+                requiredFields.remove(propertyName)
+                schema.setRequired(requiredFields)
               } else if (requiredFlag && schema.getEnum == null) {
                 addRequiredItem(schema, propertyName)
               }

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -11,7 +11,6 @@ import org.scalatest.matchers.should.Matchers
 
 import java.util
 import scala.collection.JavaConverters._
-import scala.collection.Seq
 import scala.reflect.ClassTag
 
 class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers with OptionValues {
@@ -57,18 +56,18 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val stringOpt = model.value.getProperties().get("stringOpt")
     stringOpt should not be (null)
     stringOpt.isInstanceOf[StringSchema] should be(true)
-    nullSafeSeq(stringOpt.getRequired) shouldBe empty
+    stringOpt.getRequired shouldBe null
     val stringWithDataType = model.value.getProperties().get("stringWithDataTypeOpt")
     stringWithDataType should not be (null)
     stringWithDataType shouldBe a[StringSchema]
-    nullSafeSeq(stringWithDataType.getRequired) shouldBe empty
+    stringWithDataType.getRequired shouldBe null
 
     val ipAddress = model.value.getProperties().get("ipAddress")
     ipAddress should not be (null)
     ipAddress shouldBe a[StringSchema]
     ipAddress.getDescription shouldBe "An IP address"
     ipAddress.getFormat shouldBe "IPv4 or IPv6"
-    nullSafeSeq(ipAddress.getRequired) shouldBe empty
+    ipAddress.getRequired shouldBe null
   }
 
   it should "process Option[Model] as Model" in new PropertiesScope[ModelWOptionModel] {
@@ -105,14 +104,14 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val optBigDecimal = model.value.getProperties().get("optBigDecimal")
     optBigDecimal should not be (null)
     optBigDecimal shouldBe a[NumberSchema]
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option BigInt" in new PropertiesScope[ModelWOptionBigInt] {
     val optBigInt = model.value.getProperties().get("optBigInt")
     optBigInt should not be (null)
     optBigInt shouldBe a[IntegerSchema]
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Int" in new PropertiesScope[ModelWOptionInt] {
@@ -120,7 +119,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optInt should not be (null)
     optInt shouldBe a[IntegerSchema]
     optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with nested Scala Option Int" in new PropertiesScope[NestedModelWOptionInt] {
@@ -132,7 +131,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
       optInt shouldBe a[IntegerSchema]
       optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
     }
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model without any properties" in new TestScope {
@@ -150,7 +149,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optInt shouldBe a[IntegerSchema]
     optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
     optInt.getDescription shouldBe "This is an optional int"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Int with Schema Override" in new PropertiesScope[ModelWOptionIntSchemaOverride] {
@@ -159,7 +158,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optInt shouldBe a[IntegerSchema]
     optInt.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
     optInt.getDescription shouldBe "This is an optional int"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "prioritize required as specified in annotation by default" in new PropertiesScope[ModelWOptionIntSchemaOverrideForRequired](
@@ -297,7 +296,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optLong shouldBe a[IntegerSchema]
     optLong.asInstanceOf[IntegerSchema].getFormat shouldEqual "int64"
     optLong.getDefault shouldEqual Long.MaxValue
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Long" in new PropertiesScope[ModelWOptionLong] {
@@ -305,7 +304,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optLong should not be (null)
     optLong shouldBe a[IntegerSchema]
     optLong.asInstanceOf[IntegerSchema].getFormat shouldEqual "int64"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Long with Schema Override" in new PropertiesScope[ModelWOptionLongSchemaOverride] {
@@ -313,7 +312,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optLong should not be (null)
     optLong shouldBe a[IntegerSchema]
     optLong.asInstanceOf[IntegerSchema].getFormat shouldEqual "int64"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Long with Schema Int Override" in new PropertiesScope[ModelWOptionLongSchemaIntOverride] {
@@ -321,21 +320,21 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     optLong should not be (null)
     optLong shouldBe a[IntegerSchema]
     optLong.asInstanceOf[IntegerSchema].getFormat shouldEqual "int32"
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Boolean" in new PropertiesScope[ModelWOptionBoolean] {
     val optBoolean = model.value.getProperties().get("optBoolean")
     optBoolean should not be (null)
     optBoolean shouldBe a[Schema[_]]
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala Option Boolean with Schema Override" in new PropertiesScope[ModelWOptionBooleanSchemaOverride] {
     val optBoolean = model.value.getProperties().get("optBoolean")
     optBoolean should not be (null)
     optBoolean shouldBe a[BooleanSchema]
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process all properties as required barring Option[_] or if overridden in annotation" in new TestScope {
@@ -505,7 +504,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     stringSchema.getExample shouldEqual ("42.0")
     stringSchema.getDescription shouldBe "required of annotation should be honoured"
 
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Model with Scala BigInt with annotation" in new PropertiesScope[ModelWBigIntAnnotated] {
@@ -540,7 +539,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
   it should "default to supplied schema if it can't be corrected" in new PropertiesScope[ModelWMapStringCaseClass] {
     schemas should have size 2
 
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
     val mapField = model.value.getProperties.get("maybeMapStringCaseClass")
     mapField shouldBe a[MapSchema]
     mapField.getAdditionalProperties shouldBe a[Schema[_]]
@@ -554,7 +553,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
   it should "handle Option[Map[String, Long]]" in new PropertiesScope[ModelWMapStringLong] {
     schemas should have size 1
 
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
     val mapField = model.value.getProperties.get("maybeMapStringLong")
     mapField shouldBe a[MapSchema]
     nullSafeMap(mapField.getProperties) shouldBe empty
@@ -569,7 +568,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getUniqueItems() shouldBe (null)
     arraySchema.getItems shouldBe a[StringSchema]
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Scala Seq Int" in new PropertiesScope[ModelWSeqInt] {
@@ -595,7 +594,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getUniqueItems() shouldBe (null)
     arraySchema.getItems shouldBe a[IntegerSchema]
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Scala Seq Int (annotated)" in new PropertiesScope[ModelWSeqIntAnnotated] {
@@ -608,7 +607,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getItems shouldBe a[IntegerSchema]
     arraySchema.getItems.getDescription shouldBe "These are ints"
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Scala Seq Int (annotated - old style)" in new PropertiesScope[ModelWSeqIntAnnotatedOldStyle] {
@@ -621,7 +620,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getItems shouldBe a[IntegerSchema]
     arraySchema.getItems.getDescription shouldBe "These are ints"
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Scala Set" in new PropertiesScope[ModelWSetString] {
@@ -631,7 +630,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getUniqueItems() shouldBe true
     arraySchema.getItems shouldBe a[StringSchema]
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Java List" in new PropertiesScope[ModelWJavaListString] {
@@ -641,7 +640,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     arraySchema.getUniqueItems() shouldBe (null)
     arraySchema.getItems shouldBe a[StringSchema]
     nullSafeMap(arraySchema.getProperties()) shouldBe empty
-    nullSafeSeq(arraySchema.getRequired()) shouldBe empty
+    arraySchema.getRequired() shouldBe null
   }
 
   it should "process Model with Scala Map" in new PropertiesScope[ModelWMapString] {
@@ -650,7 +649,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val mapSchema = stringsField.asInstanceOf[MapSchema]
     mapSchema.getUniqueItems() shouldBe (null)
     nullSafeMap(mapSchema.getProperties()) shouldBe empty
-    nullSafeSeq(mapSchema.getRequired()) shouldBe empty
+    mapSchema.getRequired() shouldBe null
     nullSafeSet(mapSchema.getTypes) shouldEqual Set("object")
   }
 
@@ -660,7 +659,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val mapSchema = stringsField.asInstanceOf[MapSchema]
     mapSchema.getUniqueItems() shouldBe (null)
     nullSafeMap(mapSchema.getProperties()) shouldBe empty
-    nullSafeSeq(mapSchema.getRequired()) shouldBe empty
+    mapSchema.getRequired() shouldBe null
     nullSafeSet(mapSchema.getTypes) shouldEqual Set("object")
   }
 
@@ -670,7 +669,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val mapSchema = mapField.asInstanceOf[MapSchema]
     mapSchema.getUniqueItems() shouldBe (null)
     nullSafeMap(mapSchema.getProperties()) shouldBe empty
-    nullSafeSeq(mapSchema.getRequired()) shouldBe empty
+    mapSchema.getRequired() shouldBe null
     nullSafeSet(mapSchema.getTypes) shouldEqual Set("object")
   }
 
@@ -680,7 +679,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val mapSchema = mapField.asInstanceOf[MapSchema]
     mapSchema.getUniqueItems() shouldBe (null)
     nullSafeMap(mapSchema.getProperties()) shouldBe empty
-    nullSafeSeq(mapSchema.getRequired()) shouldBe empty
+    mapSchema.getRequired() shouldBe null
     nullSafeSet(mapSchema.getTypes) shouldEqual Set("object")
   }
 
@@ -709,7 +708,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     amountField shouldBe a[IntegerSchema]
     amountField.asInstanceOf[IntegerSchema].getFormat shouldEqual "int64"
 
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process ModelWJacksonAnnotatedGetFunction" in new PropertiesScope[ModelWJacksonAnnotatedGetFunction] {
@@ -723,7 +722,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
   }
 
   it should "process Array-Model with Scala nonOption Seq (annotated)" in new PropertiesScope[ModelWStringSeqAnnotated] {
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process Array-Model with forced required Scala Option Seq (annotated)" in new PropertiesScope[ModelWOptionStringSeqAnnotated] {
@@ -739,7 +738,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
   }
 
   it should "process Array-Model with forced required Scala Option Seq" in new PropertiesScope[ModelWOptionStringSeq] {
-    nullSafeSeq(model.value.getRequired) shouldBe empty
+    model.value.getRequired shouldBe null
   }
 
   it should "process case class with Duration field" in new PropertiesScope[ModelWDuration] {


### PR DESCRIPTION
**The problem**

Whenever a required property is removed, this is done on the internal arraylist of required properties:
https://github.com/swagger-akka-http/swagger-scala-module/blob/develop/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala#L282

resulting in an empty `required` property on the model

```json
{
  "ModelWOptionBigInt" : {
    "required" : [ ],
    "type" : "object",
    "properties" : {
      "optBigInt" : {
        "type" : "integer",
        "format" : "int32"
      }
    }
  }
}
```
This does not comply with the 3.X OAS3 schema:
https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.0/schema.json#L395-L402
which defines a minimum of 1 item in the array.

**Solution**

We remove a required property by setting a new list without the property to remove. To avoid potential concurrency problems, to ensure that the correct order is retained and the `required` field is set to null if the list is empty.