### PR TITLE
ignore string type in erasure helper

### DIFF
--- a/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -27,7 +27,10 @@ private[converter] object ErasureHelper {
         val maybeClass: Option[Class[_]] = prop.typeSignature.typeArgs.headOption.flatMap { signature =>
           if (signature.typeSymbol.isClass) {
             signature.typeArgs.headOption match {
-              case Some(typeArg) => Option(mirror.runtimeClass(nestedTypeArg(typeArg)))
+              case Some(typeArg) => {
+                val resultType = nestedTypeArg(typeArg)
+                if (resultType.toString == "String") None else Option(mirror.runtimeClass(resultType))
+              }
               case _ => Option(mirror.runtimeClass(signature))
             }
           } else {

--- a/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-2/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -28,8 +28,9 @@ private[converter] object ErasureHelper {
           if (signature.typeSymbol.isClass) {
             signature.typeArgs.headOption match {
               case Some(typeArg) => {
-                val resultType = nestedTypeArg(typeArg)
-                if (resultType.toString == "String") None else Option(mirror.runtimeClass(resultType))
+                val resultType: universe.Type = nestedTypeArg(typeArg)
+                val resultClass = mirror.runtimeClass(resultType)
+                if (resultClass.isPrimitive) Option(resultClass) else None
               }
               case _ => Option(mirror.runtimeClass(signature))
             }

--- a/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -19,11 +19,14 @@ private[converter] object ErasureHelper {
           val results = classInfo.fields.flatMap { fieldInfo =>
             fieldInfo.fieldType match {
               case optionInfo: ScalaOptionInfo =>
-                Some(fieldInfo.name -> getInnerType(optionInfo.optionParamType).infoClass)
+                val innerClass = getInnerType(optionInfo.optionParamType).infoClass
+                if (innerClass.isPrimitive) Some(fieldInfo.name -> innerClass) else None
               case mapInfo: MapLikeInfo =>
-                Some(fieldInfo.name -> getInnerType(mapInfo.elementType2).infoClass)
+                val innerClass = getInnerType(mapInfo.elementType2).infoClass
+                if (innerClass.isPrimitive) Some(fieldInfo.name -> innerClass) else None
               case seqInfo: CollectionRType =>
-                Some(fieldInfo.name -> getInnerType(seqInfo.elementType).infoClass)
+                val innerClass = getInnerType(seqInfo.elementType).infoClass
+                if (innerClass.isPrimitive) Some(fieldInfo.name -> innerClass) else None
               case _ =>
                 None
             }

--- a/src/test/scala/com/github/swagger/scala/converter/ErasureHelperTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ErasureHelperTest.scala
@@ -29,4 +29,7 @@ class ErasureHelperTest extends AnyFlatSpec with Matchers {
   it should "handle OptionSeqOptionLong" in {
     ErasureHelper.erasedOptionalPrimitives(classOf[OptionSeqOptionLong]) shouldBe Map("values" -> classOf[Long])
   }
+  it should "handle OptionSetString" in {
+    ErasureHelper.erasedOptionalPrimitives(classOf[OptionSetString]) shouldBe Map.empty
+  }
 }


### PR DESCRIPTION
relates to #309 

probably best to fix the ErasureHelper to ignore String type because that is not erased like primitive types are - long, int, boolean, etc.