### PR TITLE
check ArraySchema annotation

### DIFF
--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -240,7 +240,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             val arraySchemaOverride = propertyAnnotations.collectFirst { case as: ArraySchemaAnnotation => as }
             arraySchemaOverride.flatMap { as =>
               val itemSchema = if (as.items() == null || as.items().implementation() == VoidClass) as.schema() else as.items()
-              val classOption = if (itemSchema == null || itemSchema.implementation() == VoidClass) {
+              val classOption: Option[Class[_]] = if (itemSchema == null || itemSchema.implementation() == VoidClass) {
                 None
               } else {
                 Option(itemSchema.implementation())

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.{JavaType, ObjectMapper}
 import com.fasterxml.jackson.module.scala.introspect.{BeanIntrospector, PropertyDescriptor}
 import com.fasterxml.jackson.module.scala.util.ClassW
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration}
+import com.github.swagger.scala.converter.SwaggerScalaModelConverter.nullSafeSeq
 import io.swagger.v3.core.converter._
 import io.swagger.v3.core.jackson.ModelResolver
 import io.swagger.v3.core.util.{Json, PrimitiveType}
@@ -233,6 +234,20 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             val classOption: Option[Class[_]] = if (s.implementation() == VoidClass) None else Option(s.implementation())
             classOption
           }
+          val arraySchemaOverrideClass = if (schemaOverride.isEmpty) {
+            None
+          } else {
+            val arraySchemaOverride = propertyAnnotations.collectFirst { case as: ArraySchemaAnnotation => as }
+            arraySchemaOverride.flatMap { as =>
+              val itemSchema = if (as.items() == null || as.items().implementation() == VoidClass) as.schema() else as.items()
+              val classOption = if (itemSchema == null || itemSchema.implementation() == VoidClass) {
+                None
+              } else {
+                Option(itemSchema.implementation())
+              }
+              classOption
+            }
+          }
           val maybeDefault = property.param.flatMap(_.defaultValue)
           val schemaDefaultValue = schemaOverride.flatMap { s =>
             Option(s.defaultValue()).flatMap(str => if (str.isEmpty) None else Some(str))
@@ -260,7 +275,8 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             }
           }
 
-          if (schemaProperties.nonEmpty && schemaOverrideClass.isEmpty) {
+          val overrideClass = schemaOverrideClass.orElse(arraySchemaOverrideClass)
+          if (schemaProperties.nonEmpty && overrideClass.isEmpty) {
             erasedProperties.get(propertyName).foreach { erasedType =>
               schemaProperties.get(propertyName).foreach { property =>
                 Option(PrimitiveType.fromType(erasedType)).foreach { primitiveType =>

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -234,7 +234,7 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             val classOption: Option[Class[_]] = if (s.implementation() == VoidClass) None else Option(s.implementation())
             classOption
           }
-          val arraySchemaOverrideClass = if (schemaOverride.isEmpty) {
+          val arraySchemaOverrideClass = if (schemaOverride.nonEmpty) {
             None
           } else {
             val arraySchemaOverride = propertyAnnotations.collectFirst { case as: ArraySchemaAnnotation => as }

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -182,8 +182,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val arraySchema = numbers.asInstanceOf[ArraySchema]
     arraySchema.getMinItems shouldEqual 2
     arraySchema.getMaxItems shouldEqual 10
-    // TODO - this should be an IntegerSchema but the @ArraySchema annotation items schema is not being picked up
-    // arraySchema.getItems shouldBe an[IntegerSchema]
+    arraySchema.getItems shouldBe an[IntegerSchema]
   }
 
   it should "process AddRequestOldStyleAnnotation" in new PropertiesScope[AddRequestOldStyleAnnotation] {
@@ -193,8 +192,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val arraySchema = numbers.asInstanceOf[ArraySchema]
     arraySchema.getMinItems shouldEqual 2
     arraySchema.getMaxItems shouldEqual 10
-    // TODO - this should be an IntegerSchema but the @ArraySchema annotation items schema is not being picked up
-    // arraySchema.getItems shouldBe an[IntegerSchema]
+    arraySchema.getItems shouldBe an[IntegerSchema]
   }
 
   it should "process Model without any properties" in new TestScope {

--- a/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ModelPropertyParserTest.scala
@@ -182,7 +182,8 @@ class ModelPropertyParserTest extends AnyFlatSpec with BeforeAndAfterEach with M
     val arraySchema = numbers.asInstanceOf[ArraySchema]
     arraySchema.getMinItems shouldEqual 2
     arraySchema.getMaxItems shouldEqual 10
-    arraySchema.getItems shouldBe an[IntegerSchema]
+    // assertion disabled due to https://github.com/swagger-api/swagger-core/issues/4610
+    // arraySchema.getItems shouldBe an[IntegerSchema]
   }
 
   it should "process AddRequestOldStyleAnnotation" in new PropertiesScope[AddRequestOldStyleAnnotation] {


### PR DESCRIPTION
My current best guess is that https://github.com/swagger-api/swagger-core/issues/4610 is causing the test failure. I don't normally get much response when I raise issues with the Swagger team so I'm not confident it will be addressed.

@jgulotta I could just press on and not try to support the `items` field on the ArraySchema and concentrate on the `schema` field - would this work for you?