### PR TITLE
Cache what is worked out about a model class by reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a fork of https://github.com/swagger-api/swagger-scala-module.
 
 | Release | Supports |
 | ------- | -------- |
-| 2.16.x | Scala 3 builds no longer depend on `scala3-reflection` - see section on Scala 3 type information below. Jackson 2.22. |
+| 2.16.x | Scala 3 builds no longer depend on `scala3-reflection` - see section on Scala 3 type information below. Per class introspection is now cached. Jackson 2.22. |
 | 2.15.x | Jackson 2.21. |
 | 2.14.x | Jackson 2.19. |
 | 2.13.x | Jackson 2.18. |
@@ -31,6 +31,19 @@ To enable the swagger-scala-module, include the appropriate version in your proj
 
 ## How does it work?
 Including the library in your project allows the swagger extension module to discover this module, bringing in the appropriate jackson library in the process.  You can then use scala classes and objects in your swagger project.
+
+## Caching
+
+Working out the properties of a model class, their types and their annotations is by far the most expensive thing this module does per resolve - most of it inside jackson-module-scala's `BeanIntrospector` - and none of it can change while an application is running. Since v2.16.0 it is worked out once per class and cached, which roughly halves what this module adds to a `readAll` call.
+
+The cache holds 1000 classes by default and evicts the least recently used, like the caches jackson keeps for its own class lookups. It can be resized, or turned off with a size of zero, and emptied if the classes it holds have to be released - when an application is redeployed without its classloader being discarded, for instance:
+
+```scala
+SwaggerScalaModelConverter.setIntrospectionCacheSize(2000)
+SwaggerScalaModelConverter.clearIntrospectionCache()
+```
+
+Anything that can change while the application runs stays outside the cache and is worked out on each resolve: the settings described below, and the Scala 3 type information, so that a class registered after its schema has been generated still takes effect.
 
 ## Treatment of `Option` and `required`
 

--- a/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
+++ b/src/main/scala-3/com/github/swagger/scala/converter/ErasureHelper.scala
@@ -11,7 +11,7 @@ private[converter] object ErasureHelper {
     ScalaModelRegistry.infoFor(cls) match {
       case Some(info) => info.erasedPrimitives
       case None =>
-        if (MissingTypeInfo.hasErasedGenericFields(cls)) MissingTypeInfo.warnOnce(cls)
+        MissingTypeInfo.warnIfErased(cls)
         Map.empty[String, Class[?]]
     }
   }

--- a/src/main/scala-3/com/github/swagger/scala/converter/MissingTypeInfo.scala
+++ b/src/main/scala-3/com/github/swagger/scala/converter/MissingTypeInfo.scala
@@ -11,13 +11,27 @@ import scala.util.control.NonFatal
   */
 private[converter] object MissingTypeInfo {
   private val logger = LoggerFactory.getLogger(MissingTypeInfo.getClass)
+  // the probes are Java reflection and a class is resolved many times over the life of an application, so each one is run once per
+  // class - they are separate, because whichever helper is called first must not stop the other one from ever probing
+  private val erasureChecked = ConcurrentHashMap.newKeySet[String]()
+  private val subtypesChecked = ConcurrentHashMap.newKeySet[String]()
   private val warned = ConcurrentHashMap.newKeySet[String]()
   private val ObjectClass = classOf[Object]
   private val OptionClass = classOf[Option[?]]
   private val IterableClass = classOf[scala.collection.Iterable[?]]
   private val MapClass = classOf[scala.collection.Map[?, ?]]
 
-  def warnOnce(cls: Class[?]): Unit = {
+  /** Warns if this class has fields whose element type has been erased and no type information to put it back. */
+  def warnIfErased(cls: Class[?]): Unit = {
+    if (erasureChecked.add(cls.getName) && hasErasedGenericFields(cls)) warnOnce(cls)
+  }
+
+  /** Warns if this class could be a sealed Scala 3 type whose subtypes are not known. */
+  def warnIfSealed(cls: Class[?]): Unit = {
+    if (subtypesChecked.add(cls.getName) && couldBeSealed(cls)) warnOnce(cls)
+  }
+
+  private def warnOnce(cls: Class[?]): Unit = {
     if (warned.add(cls.getName)) {
       logger.warn(
         s"No Scala 3 type information is available for ${cls.getName} - its schema may be missing the element types of its Option and " +

--- a/src/main/scala-3/com/github/swagger/scala/converter/SubtypeHelper.scala
+++ b/src/main/scala-3/com/github/swagger/scala/converter/SubtypeHelper.scala
@@ -11,7 +11,7 @@ object SubtypeHelper {
     ScalaModelRegistry.infoFor(cls) match {
       case Some(info) => info.subtypes
       case None =>
-        if (MissingTypeInfo.couldBeSealed(cls)) MissingTypeInfo.warnOnce(cls)
+        MissingTypeInfo.warnIfSealed(cls)
         Seq.empty
     }
   }

--- a/src/main/scala/com/github/swagger/scala/converter/ClassIntrospection.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/ClassIntrospection.scala
@@ -1,0 +1,191 @@
+package com.github.swagger.scala.converter
+
+import com.fasterxml.jackson.module.scala.introspect.{BeanIntrospector, PropertyDescriptor}
+import io.swagger.v3.oas.annotations.media.{ArraySchema => ArraySchemaAnnotation, Schema => SchemaAnnotation}
+
+import com.fasterxml.jackson.databind.util.LRUMap
+
+import java.lang.annotation.Annotation
+
+/** What the converter needs to know about one property of a model class, worked out once for the class rather than on every resolve. */
+private[converter] final class PropertyIntrospection(
+    val name: String,
+    val annotatedName: String,
+    val propertyClass: Class[_],
+    val annotations: Seq[Annotation],
+    val isOption: Boolean,
+    val isIterable: Boolean,
+    val isMap: Boolean,
+    val schemaOverrideClass: Option[Class[_]],
+    val arraySchemaOverrideClass: Option[Class[_]],
+    val schemaDefaultValue: Option[String],
+    val defaultValue: Option[() => Any]
+) {
+
+  /** Whether the property has a default value, either in the Scala constructor or in a Schema annotation. */
+  val hasDefaultValue: Boolean = schemaDefaultValue.nonEmpty || defaultValue.nonEmpty
+
+  /** The class the schema of this property should be overridden with, if any. */
+  val overrideClass: Option[Class[_]] = schemaOverrideClass.orElse(arraySchemaOverrideClass)
+}
+
+private[converter] final class ClassIntrospection(val properties: Seq[PropertyIntrospection]) {
+
+  /** The names the properties of this class have in a generated schema. */
+  val annotatedNames: Set[String] = properties.map(_.annotatedName).toSet
+}
+
+/** Caches what can be worked out about a model class by reflection.
+  *
+  * Introspecting a class is the most expensive thing this module does per resolve - most of it inside jackson-module-scala's
+  * `BeanIntrospector` - and none of it can change while the application is running, so it is worked out once per class.
+  *
+  * Only facts that are fixed for a class are held here. Anything that depends on how the converter is configured, such as
+  * [[SwaggerScalaModelConverter.setRequiredBasedOnAnnotation]], and anything that can be registered later, such as the erased element types
+  * of [[ScalaModelRegistry]], is still worked out on each resolve.
+  */
+private[converter] object ClassIntrospection {
+  private val VoidClass = classOf[Void]
+  private val OptionClass = classOf[scala.Option[_]]
+  private val IterableClass = classOf[scala.collection.Iterable[_]]
+  private val MapClass = classOf[scala.collection.Map[_, _]]
+  private val AnyClass = classOf[Any]
+  // https://github.com/swagger-api/swagger-core/issues/5076
+  // hardcode here to avoid having an explicit dependence on the new DEFAULT_SENTINEL field in swagger-annotations
+  private val DefaultSentinel = "##default"
+  private val DefaultMaxEntries = 1000
+
+  // the same bounded cache jackson uses for its own class lookups, so that a long lived application cannot accumulate
+  // introspections without limit, and a redeployed one does not hold on to the classes of the previous deployment for ever
+  @volatile private var cache = new LRUMap[Class[_], ClassIntrospection](16, DefaultMaxEntries)
+  @volatile private var maxEntries = DefaultMaxEntries
+
+  def of(cls: Class[_]): ClassIntrospection = {
+    val cached = cache.get(cls)
+    if (cached ne null) {
+      cached
+    } else {
+      val introspection = introspect(cls)
+      if (maxEntries > 0) cache.putIfAbsent(cls, introspection)
+      introspection
+    }
+  }
+
+  def clear(): Unit = cache.clear()
+
+  /** Sets how many classes the cache holds. Zero introspects a class on every resolve, which is what this module did before v2.16.0. */
+  def setMaxEntries(value: Int): Unit = {
+    maxEntries = value
+    cache = new LRUMap[Class[_], ClassIntrospection](16.min(value.max(1)), value.max(1))
+  }
+
+  def getMaxEntries: Int = maxEntries
+
+  private def introspect(cls: Class[_]): ClassIntrospection = {
+    val properties = BeanIntrospector(cls).properties.map { property =>
+      val annotations = getPropertyAnnotations(property)
+      val schemaOverride = annotations.collectFirst { case s: SchemaAnnotation => s }
+      val schemaOverrideClass = schemaOverride.flatMap { s =>
+        // this form is needed by the Scala 2.11 compiler
+        val classOption: Option[Class[_]] = if (s.implementation() == VoidClass) None else Option(s.implementation())
+        classOption
+      }
+      val arraySchemaOverrideClass = if (schemaOverride.nonEmpty) {
+        None
+      } else {
+        annotations.collectFirst { case as: ArraySchemaAnnotation => as }.flatMap { as =>
+          val itemSchema = as.schema()
+          val classOption: Option[Class[_]] = if (itemSchema == null || itemSchema.implementation() == VoidClass) {
+            None
+          } else {
+            Option(itemSchema.implementation())
+          }
+          classOption
+        }
+      }
+      val schemaDefaultValue = schemaOverride.flatMap { s =>
+        Option(s.defaultValue()).flatMap { str =>
+          if (str.isEmpty || str == DefaultSentinel) None else Some(str)
+        }
+      }
+      val annotatedName = schemaOverride match {
+        case Some(ann) if ann.name().nonEmpty => ann.name()
+        case _ => property.name
+      }
+      val propertyClass = getPropertyClass(property)
+      new PropertyIntrospection(
+        name = property.name,
+        annotatedName = annotatedName,
+        propertyClass = propertyClass,
+        annotations = annotations,
+        isOption = propertyClass == OptionClass,
+        isIterable = IterableClass.isAssignableFrom(propertyClass),
+        isMap = MapClass.isAssignableFrom(propertyClass),
+        schemaOverrideClass = schemaOverrideClass,
+        arraySchemaOverrideClass = arraySchemaOverrideClass,
+        schemaDefaultValue = schemaDefaultValue,
+        defaultValue = property.param.flatMap(_.defaultValue)
+      )
+    }
+    new ClassIntrospection(properties)
+  }
+
+  private def getPropertyClass(property: PropertyDescriptor): Class[_] = {
+    property.param match {
+      case Some(constructorParameter) =>
+        val types = constructorParameter.constructor.getParameterTypes
+        val index = constructorParameter.index
+        if (index > types.size) {
+          AnyClass
+        } else {
+          types(index)
+        }
+      case _ =>
+        property.field match {
+          case Some(field) => field.getType
+          case _ =>
+            property.setter match {
+              case Some(setter) if setter.getParameterCount == 1 => {
+                setter.getParameterTypes()(0)
+              }
+              case _ =>
+                property.beanSetter match {
+                  case Some(setter) if setter.getParameterCount == 1 => {
+                    setter.getParameterTypes()(0)
+                  }
+                  case _ => AnyClass
+                }
+            }
+        }
+    }
+  }
+
+  private def getPropertyAnnotations(property: PropertyDescriptor): Seq[Annotation] = {
+    val fieldAnnotations = property.field match {
+      case Some(field) => field.getAnnotations.toSeq
+      case _ => Seq.empty
+    }
+    val setterAnnotations = property.setter match {
+      case Some(setter) => setter.getAnnotations.toSeq
+      case _ => Seq.empty
+    }
+    val beanSetterAnnotations = property.beanSetter match {
+      case Some(beanSetter) => beanSetter.getAnnotations.toSeq
+      case _ => Seq.empty
+    }
+    val paramAnnotations = property.param match {
+      case Some(constructorParameter) => {
+        val types = constructorParameter.constructor.getParameterTypes
+        val annotations = constructorParameter.constructor.getParameterAnnotations
+        val index = constructorParameter.index
+        if (index > types.size || index > annotations.size) {
+          Seq.empty
+        } else {
+          annotations(index).toIndexedSeq
+        }
+      }
+      case _ => Seq.empty
+    }
+    (paramAnnotations ++ fieldAnnotations ++ setterAnnotations ++ beanSetterAnnotations).distinct
+  }
+}

--- a/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -2,7 +2,6 @@ package com.github.swagger.scala.converter
 
 import com.fasterxml.jackson.databind.`type`.ReferenceType
 import com.fasterxml.jackson.databind.{JavaType, ObjectMapper}
-import com.fasterxml.jackson.module.scala.introspect.{BeanIntrospector, PropertyDescriptor}
 import com.fasterxml.jackson.module.scala.util.ClassW
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration}
 import io.swagger.v3.core.converter._
@@ -85,6 +84,29 @@ object SwaggerScalaModelConverter {
     * @since v2.7.6
     */
   def isRequiredBasedOnDefaultValue: Boolean = requiredBasedOnDefaultValue
+
+  /** What this module works out about a model class by reflection - its properties, their types and their annotations - is cached, because
+    * none of it can change while the application is running, and introspecting a class is by far the most expensive thing this module does.
+    * This sets how many classes the cache holds.
+    *
+    * @param value
+    *   1000 by default. Zero introspects a class on every resolve, as this module did before v2.16.0.
+    * @since v2.16.0
+    */
+  def setIntrospectionCacheSize(value: Int): Unit = ClassIntrospection.setMaxEntries(value)
+
+  /** @return
+    *   how many classes the introspection cache holds
+    * @since v2.16.0
+    */
+  def getIntrospectionCacheSize: Int = ClassIntrospection.getMaxEntries
+
+  /** Empties the introspection cache. Only needed if the classes it holds have to be released, e.g. when an application is redeployed
+    * without its classloader being discarded.
+    *
+    * @since v2.16.0
+    */
+  def clearIntrospectionCache(): Unit = ClassIntrospection.clear()
 
   /** @param annotatedType
     * @return
@@ -221,45 +243,19 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
   ): Option[Schema[_]] = {
     if (chain.hasNext) {
       Option(chain.next().resolve(`type`, context, chain)).map { schema =>
-        val introspector = BeanIntrospector(cls)
-        filterUnwantedProperties(schema, introspector.properties)
+        // worked out once per class - see ClassIntrospection
+        val introspection = ClassIntrospection.of(cls)
+        filterUnwantedProperties(schema, introspection)
+        // not part of the introspection: a class can be registered after it has first been introspected
         val erasedProperties = ErasureHelper.erasedOptionalPrimitives(cls)
         val schemaProperties = nullSafeMap(schema.getProperties)
-        introspector.properties.foreach { property =>
+        introspection.properties.foreach { property =>
           val propertyName = property.name
-          val propertyClass = getPropertyClass(property)
-          val propertyAnnotations = getPropertyAnnotations(property)
-          val isOptional = isOption(propertyClass)
-          val schemaOverride = propertyAnnotations.collectFirst { case s: SchemaAnnotation => s }
-          val schemaOverrideClass = schemaOverride.flatMap { s =>
-            // this form is needed by the Scala 2.11 compiler
-            val classOption: Option[Class[_]] = if (s.implementation() == VoidClass) None else Option(s.implementation())
-            classOption
-          }
-          val arraySchemaOverrideClass = if (schemaOverride.nonEmpty) {
-            None
-          } else {
-            val arraySchemaOverride = propertyAnnotations.collectFirst { case as: ArraySchemaAnnotation => as }
-            arraySchemaOverride.flatMap { as =>
-              val itemSchema = as.schema()
-              val classOption: Option[Class[_]] = if (itemSchema == null || itemSchema.implementation() == VoidClass) {
-                None
-              } else {
-                Option(itemSchema.implementation())
-              }
-              classOption
-            }
-          }
-          val maybeDefault = property.param.flatMap(_.defaultValue)
-          val schemaDefaultValue = schemaOverride.flatMap { s =>
-            Option(s.defaultValue()).flatMap { str =>
-              if (str.isEmpty || str == SwaggerScalaModelConverter.DEFAULT_SENTINEL)
-                None
-              else
-                Some(str)
-            }
-          }
-          val hasDefaultValue = schemaDefaultValue.nonEmpty || maybeDefault.nonEmpty
+          val propertyAnnotations = property.annotations
+          val isOptional = property.isOption
+          val maybeDefault = property.defaultValue
+          val schemaDefaultValue = property.schemaDefaultValue
+          val hasDefaultValue = property.hasDefaultValue
 
           if (schemaDefaultValue.isEmpty) {
             // default values set in annotation leads to default values set in Scala constructor being ignored
@@ -282,16 +278,15 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
             }
           }
 
-          val overrideClass = schemaOverrideClass.orElse(arraySchemaOverrideClass)
-          if (schemaProperties.nonEmpty && overrideClass.isEmpty) {
+          if (schemaProperties.nonEmpty && property.overrideClass.isEmpty) {
             erasedProperties.get(propertyName).foreach { erasedType =>
-              schemaProperties.get(propertyName).foreach { property =>
+              schemaProperties.get(propertyName).foreach { propertySchema =>
                 Option(PrimitiveType.fromType(erasedType)).foreach { primitiveType =>
                   if (isOptional) {
-                    schema.addProperty(propertyName, tryCorrectSchema(property, primitiveType))
+                    schema.addProperty(propertyName, tryCorrectSchema(propertySchema, primitiveType))
                   }
-                  if (isIterable(propertyClass) && !isMap(propertyClass)) {
-                    schema.addProperty(propertyName, updateTypeOnItemsSchema(primitiveType, property))
+                  if (property.isIterable && !property.isMap) {
+                    schema.addProperty(propertyName, updateTypeOnItemsSchema(primitiveType, propertySchema))
                   }
                 }
               }
@@ -322,22 +317,14 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
     }
   }
 
-  private def filterUnwantedProperties(schema: Schema[_], propertiesToKeep: Seq[PropertyDescriptor]): Unit = {
-    val propNamesSet = propertiesToKeep.map(getAnnotatedPropertyName).toSet
+  private def filterUnwantedProperties(schema: Schema[_], introspection: ClassIntrospection): Unit = {
+    val propNamesSet = introspection.annotatedNames
     val originalProps = nullSafeMap(schema.getProperties)
     val newProps = originalProps.filter { case (key, _) =>
       propNamesSet.contains(key)
     }
     if (originalProps.size > newProps.size) {
       schema.setProperties(new util.LinkedHashMap(newProps.asJava))
-    }
-  }
-
-  private def getAnnotatedPropertyName(property: PropertyDescriptor): String = {
-    val propertyAnnotations = getPropertyAnnotations(property)
-    propertyAnnotations.collectFirst { case s: SchemaAnnotation => s } match {
-      case Some(ann) if ann.name().nonEmpty => ann.name()
-      case _ => property.name
     }
   }
 
@@ -504,65 +491,6 @@ class SwaggerScalaModelConverter extends ModelResolver(SwaggerScalaModelConverte
         }
       }
     }
-  }
-
-  private def getPropertyClass(property: PropertyDescriptor): Class[_] = {
-    property.param match {
-      case Some(constructorParameter) =>
-        val types = constructorParameter.constructor.getParameterTypes
-        val index = constructorParameter.index
-        if (index > types.size) {
-          AnyClass
-        } else {
-          types(index)
-        }
-      case _ =>
-        property.field match {
-          case Some(field) => field.getType
-          case _ =>
-            property.setter match {
-              case Some(setter) if setter.getParameterCount == 1 => {
-                setter.getParameterTypes()(0)
-              }
-              case _ =>
-                property.beanSetter match {
-                  case Some(setter) if setter.getParameterCount == 1 => {
-                    setter.getParameterTypes()(0)
-                  }
-                  case _ => AnyClass
-                }
-            }
-        }
-    }
-  }
-
-  private def getPropertyAnnotations(property: PropertyDescriptor): Seq[Annotation] = {
-    val fieldAnnotations = property.field match {
-      case Some(field) => field.getAnnotations.toSeq
-      case _ => Seq.empty
-    }
-    val setterAnnotations = property.setter match {
-      case Some(setter) => setter.getAnnotations.toSeq
-      case _ => Seq.empty
-    }
-    val beanSetterAnnotations = property.beanSetter match {
-      case Some(beanSetter) => beanSetter.getAnnotations.toSeq
-      case _ => Seq.empty
-    }
-    val paramAnnotations = property.param match {
-      case Some(constructorParameter) => {
-        val types = constructorParameter.constructor.getParameterTypes
-        val annotations = constructorParameter.constructor.getParameterAnnotations
-        val index = constructorParameter.index
-        if (index > types.size || index > annotations.size) {
-          Seq.empty
-        } else {
-          annotations(index).toIndexedSeq
-        }
-      }
-      case _ => Seq.empty
-    }
-    (paramAnnotations ++ fieldAnnotations ++ setterAnnotations ++ beanSetterAnnotations).distinct
   }
 
   private def isOption(cls: Class[_]): Boolean = cls == OptionClass

--- a/src/test/scala-3/com/github/swagger/scala/converter/ScalaModelRegistryTest.scala
+++ b/src/test/scala-3/com/github/swagger/scala/converter/ScalaModelRegistryTest.scala
@@ -1,7 +1,7 @@
 package com.github.swagger.scala.converter
 
 import io.swagger.v3.core.converter.ModelConverters
-import io.swagger.v3.oas.models.media.{IntegerSchema, ObjectSchema}
+import io.swagger.v3.oas.models.media.{IntegerSchema, ObjectSchema, Schema}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -26,6 +26,8 @@ object ScalaModelRegistryTest {
     def iterator: Iterator[Long] = Iterator.empty
   }
   case class HoldsLongList(values: LongList, optLong: Option[Long])
+
+  case class LateRegistered(optInt: Option[Int])
 }
 
 class ScalaModelRegistryTest extends AnyFlatSpec with Matchers {
@@ -66,6 +68,15 @@ class ScalaModelRegistryTest extends AnyFlatSpec with Matchers {
     ScalaModelRegistry.isRegistered(classOf[Unregistered]) shouldBe false
     ErasureHelper.erasedOptionalPrimitives(classOf[Unregistered]) shouldBe empty
     SubtypeHelper.findSubtypes(classOf[UnregisteredShape]) shouldBe empty
+  }
+
+  it should "apply to a class that has already been introspected" in {
+    // the class introspection is cached, so registering a class after its schema has been generated has to still take effect
+    def optIntSchema(): Schema[?] =
+      ModelConverters.getInstance().readAll(classOf[LateRegistered]).asScala("LateRegistered").getProperties.asScala("optInt")
+    optIntSchema() shouldBe an[ObjectSchema]
+    ScalaModelRegistry.register[LateRegistered]
+    optIntSchema() shouldBe an[IntegerSchema]
   }
 
   it should "generate accurate schemas for registered classes" in {

--- a/src/test/scala/com/github/swagger/scala/converter/ClassIntrospectionTest.scala
+++ b/src/test/scala/com/github/swagger/scala/converter/ClassIntrospectionTest.scala
@@ -1,0 +1,63 @@
+package com.github.swagger.scala.converter
+
+import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.core.util.Json
+import models._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class ClassIntrospectionTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
+  TestModelRegistration.register()
+
+  private val converters = ModelConverters.getInstance()
+  private val modelClass = classOf[ModelWOptionIntSchemaOverrideForRequired]
+
+  override protected def afterEach(): Unit = {
+    SwaggerScalaModelConverter.setIntrospectionCacheSize(1000)
+    SwaggerScalaModelConverter.setRequiredBasedOnAnnotation(true)
+    SwaggerScalaModelConverter.setRequiredBasedOnDefaultValue(true)
+  }
+
+  private def schemaOf(cls: Class[_]): String = Json.pretty(converters.readAll(cls))
+
+  private def requiredFieldsOf(cls: Class[_]): Set[String] = {
+    val schema = converters.readAll(cls).asScala(cls.getSimpleName)
+    Option(schema.getRequired).map(_.asScala.toSet).getOrElse(Set.empty)
+  }
+
+  "ClassIntrospection" should "generate the same schema whether a class is cached or introspected every time" in {
+    SwaggerScalaModelConverter.setIntrospectionCacheSize(0)
+    val uncached = schemaOf(modelClass)
+    SwaggerScalaModelConverter.setIntrospectionCacheSize(1000)
+    schemaOf(modelClass) shouldEqual uncached // this one fills the cache
+    schemaOf(modelClass) shouldEqual uncached // this one reads it
+    SwaggerScalaModelConverter.clearIntrospectionCache()
+    schemaOf(modelClass) shouldEqual uncached
+  }
+
+  it should "keep generating schemas for classes that do not fit in the cache" in {
+    SwaggerScalaModelConverter.setIntrospectionCacheSize(1)
+    val first = schemaOf(modelClass)
+    schemaOf(classOf[ModelWSeqInt]) should not be empty
+    schemaOf(classOf[ModelWOptionString]) should not be empty
+    schemaOf(modelClass) shouldEqual first
+  }
+
+  it should "not cache what depends on how the converter is configured" in {
+    SwaggerScalaModelConverter.setRequiredBasedOnDefaultValue(true)
+    val basedOnDefaultValue = requiredFieldsOf(modelClass)
+    // the class has been introspected by now, so this only changes if the required settings are worked out per resolve
+    SwaggerScalaModelConverter.setRequiredBasedOnDefaultValue(false)
+    val notBasedOnDefaultValue = requiredFieldsOf(modelClass)
+    basedOnDefaultValue shouldEqual Set("annotatedOptionalInt", "requiredInt")
+    notBasedOnDefaultValue shouldEqual Set("annotatedOptionalInt", "requiredInt", "requiredIntWithDefault")
+  }
+
+  it should "expose the cache size it was given" in {
+    SwaggerScalaModelConverter.setIntrospectionCacheSize(42)
+    SwaggerScalaModelConverter.getIntrospectionCacheSize shouldBe 42
+  }
+}


### PR DESCRIPTION
Stacked on #516 - review that one first, this branch targets it rather than `develop`.

Follow-up to the `derives` work, asking where compile time information can save runtime work. The answer turned out to be mostly measurement, so here it is up front.

## What is actually expensive

Minimum of 6 measured rounds, variants interleaved in one JVM (`ModelConverters.getInstance()` vs a bare `new ModelConverters()`, which is swagger-core's `ModelResolver` on its own):

| | swagger-core alone | with this module, before | with this module, after |
| --- | --- | --- | --- |
| Scala 3, 10 field model | 2.60 ms | 4.49 ms (+1.89) | 3.40 ms (+0.80) |
| Scala 3, 1 field model | 0.97 ms | 1.37 ms (+0.40) | 1.26 ms (+0.29) |
| Scala 2.13, 10 field model | 2.67 ms | 5.42 ms (+2.74) | 4.12 ms (+1.45) |
| Scala 2.13, 1 field model | 1.12 ms | 1.77 ms (+0.65) | 1.44 ms (+0.32) |

So this module was adding 40-50% on top of swagger-core, and about half of that was `BeanIntrospector`, at 0.93-1.2 ms for a 10 field class, rerun on every single resolve. The rest of the per-resolve reflection was small but not free - `Constructor.getParameterAnnotations` alone is 0.03 ms per property, and it was called once per property per resolve.

What was *not* expensive, measured for completeness: the registry lookups from #516 (0.0001 ms), `ClassW.hasSignature` (0.0001 ms), and `tryCorrectSchema`'s json round trip (0.0025 ms). The overhead that remains after this change is mostly swagger-core being re-entered to resolve the unwrapped type of an `Option` property, which is inherent to how the unboxing works.

## What this changes

`ClassIntrospection` works out the properties of a class, their types, their annotations, the `@Schema`/`@ArraySchema` overrides they carry, their annotated names and their default values **once per class**, and holds them in a `LRUMap` - the bounded cache jackson uses for its own class lookups - so a long lived application cannot accumulate introspections without limit.

Only facts that are fixed for a class go in the cache. Deliberately left out, and covered by tests:

* the required settings, which consult `setRequiredBasedOnAnnotation` / `setRequiredBasedOnDefaultValue` on each resolve
* the erased element types, which are read from `ScalaModelRegistry` on each resolve, so **a class registered (or derived) after its schema has already been generated still takes effect** - this is the trap in caching a class whose type information can arrive later, and there is a Scala 3 test that resolves `LateRegistered`, checks it comes out as an object schema, registers it, and checks it comes out as an integer schema

`setIntrospectionCacheSize` and `clearIntrospectionCache` are exposed for applications that need to resize the cache or release the classes it holds, e.g. a redeploy that keeps the classloader. A size of zero restores the old introspect-every-time behaviour, which is also how the tests compare cached and uncached output.

Also, the Scala 3 probes that decide whether an unregistered class is worth warning about (`getDeclaredFields` walking generic signatures, and a `.tasty` resource lookup at 0.011 ms) were running on every resolve of such a class, and now run once per class. Their gates are separate, so whichever of `ErasureHelper`/`SubtypeHelper` runs first does not stop the other from ever probing - `SubtypeHelper` runs first for every type, so a single shared gate would have silently suppressed every erasure warning.

## On pushing more to compile time

Worth recording what was considered and rejected. The macro from #516 could in principle emit the whole property model - names, annotations, defaults - and skip Jackson entirely. It should not: the property names and visibility rules that Jackson's `BeanIntrospector` produces are the same ones that drive the schema property names, and a macro reimplementation that diverged even slightly would produce wrong schemas rather than slow ones. Caching gets most of the win at no behavioural risk, and it benefits Scala 2 equally, where there is no macro at all.

## Testing

`sbt test` passes on 2.11.12, 2.12.21 and 2.13.18 (87 tests each) and on 3.3.8 (106 tests). New tests cover cached vs uncached output being identical, output after `clearIntrospectionCache`, classes that overflow the cache, the configuration settings not being cached, and late registration still applying. `scalafmtCheck` passes for both dialects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4oMFg51QnrwcVaMUgBUus